### PR TITLE
Dependabot cannot update omniauth-saml to a non-vulnerable version

### DIFF
--- a/omniauth-quickbooks-oauth2.gemspec
+++ b/omniauth-quickbooks-oauth2.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'omniauth', '~>2.0.4'
+  spec.add_dependency 'omniauth', '~>2.1'
   spec.add_dependency 'omniauth-oauth2', '~>1.5'
 
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
In version omniauth 2.0.4, we got omniauth-saml vulnerable to Improper Verification of Cryptographic Signature.

`gem "omniauth-quickbooks-oauth2", path: "https://github.com/AtoB-Developers/omniauth-quickbooks-oauth2", branch: "Update_Gemspec"`
As Every version of omniauth-quickbooks-oauth2 depends on omniauth ~> 2.0.4 and omniauth-saml >= 2.1.2 depends on omniauth ~> 2.1.

more info: https://vulert.com/vuln-db/rubygems-omniauth-saml-150311

##Testing

Before update omniauth got
<img width="720" alt="Screenshot 2025-01-29 at 7 39 17 PM" src="https://github.com/user-attachments/assets/cca9d445-5b44-4a91-9af0-f446bae54bc8" />

After updating omniauth ~> 2.1 in omniauth-quickbooks-oauth2
<img width="665" alt="Screenshot 2025-01-29 at 7 47 57 PM" src="https://github.com/user-attachments/assets/bf438571-bc34-4564-a885-149ff95db5c8" />

